### PR TITLE
Add optional RKYV serialization support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 keywords = ["ip", "networking", "trie", "cidr"]
 categories = ["data-structures", "network-programming"]
 
+[dependencies]
+bytecheck = { version = "~0.6.8", default-features = false, optional = true }
+rkyv = { version = "0.7.42", features = ["validation", "strict"], optional = true }
+
 [dev-dependencies]
 rand = "0.7.2"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub use address::addr::*;
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
 #[cfg_attr(feature = "bytecheck", archive_attr(derive(rkyv::CheckBytes)))]
-pub struct IpLookupTable<A, T: Clone + Copy + Default> {
+pub struct IpLookupTable<A, T> {
     inner: TreeBitmap<T>,
     _addrtype: PhantomData<A>,
 }
@@ -424,7 +424,7 @@ where
 /// Iterator over prefixes and associated values. The prefixes are returned in
 /// "tree"-order.
 #[doc(hidden)]
-pub struct Iter<'a, A, T: 'a + Clone + Copy + Default> {
+pub struct Iter<'a, A, T: 'a> {
     inner: tree_bitmap::Iter<'a, T>,
     _addrtype: PhantomData<A>,
 }
@@ -432,7 +432,7 @@ pub struct Iter<'a, A, T: 'a + Clone + Copy + Default> {
 /// Mutable iterator over prefixes and associated values. The prefixes are
 /// returned in "tree"-order.
 #[doc(hidden)]
-pub struct IterMut<'a, A, T: 'a + Clone + Copy + Default> {
+pub struct IterMut<'a, A, T: 'a> {
     inner: tree_bitmap::IterMut<'a, T>,
     _addrtype: PhantomData<A>,
 }
@@ -440,7 +440,7 @@ pub struct IterMut<'a, A, T: 'a + Clone + Copy + Default> {
 /// Converts ```IpLookupTable``` into an iterator. The prefixes are returned in
 /// "tree"-order.
 #[doc(hidden)]
-pub struct IntoIter<A, T: Clone + Copy + Default> {
+pub struct IntoIter<A, T> {
     inner: tree_bitmap::IntoIter<T>,
     _addrtype: PhantomData<A>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@
 
 #[cfg(feature = "alloc")]
 extern crate alloc;
+#[cfg(feature = "rkyv")]
+extern crate rkyv;
+
 #[cfg(feature = "alloc")]
 use core as std;
 use std::marker::PhantomData;
@@ -34,6 +37,11 @@ use address::Address;
 pub use address::addr::*;
 
 /// A fast, compressed IP lookup table.
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "bytecheck", archive_attr(derive(rkyv::CheckBytes)))]
 pub struct IpLookupTable<A, T: Clone + Copy + Default> {
     inner: TreeBitmap<T>,
     _addrtype: PhantomData<A>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@
 extern crate alloc;
 #[cfg(feature = "alloc")]
 use core as std;
-
 use std::marker::PhantomData;
 
 mod tree_bitmap;
@@ -35,7 +34,7 @@ use address::Address;
 pub use address::addr::*;
 
 /// A fast, compressed IP lookup table.
-pub struct IpLookupTable<A, T> {
+pub struct IpLookupTable<A, T: Clone + Copy + Default> {
     inner: TreeBitmap<T>,
     _addrtype: PhantomData<A>,
 }
@@ -43,6 +42,7 @@ pub struct IpLookupTable<A, T> {
 impl<A, T> IpLookupTable<A, T>
 where
     A: Address,
+    T: Clone + Copy + Default,
 {
     /// Initialize an empty lookup table with no preallocation.
     pub fn new() -> Self {
@@ -339,15 +339,17 @@ where
 impl<A, T> Default for IpLookupTable<A, T>
 where
     A: Address,
+    T: Clone + Copy + Default,
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a, A, T: 'a> Iterator for Iter<'a, A, T>
+impl<'a, A, T> Iterator for Iter<'a, A, T>
 where
     A: Address,
+    T: 'a + Clone + Copy + Default,
 {
     type Item = (A, u32, &'a T);
 
@@ -361,9 +363,10 @@ where
     }
 }
 
-impl<'a, A, T: 'a> Iterator for IterMut<'a, A, T>
+impl<'a, A, T> Iterator for IterMut<'a, A, T>
 where
     A: Address,
+    T: 'a + Clone + Copy + Default,
 {
     type Item = (A, u32, &'a mut T);
 
@@ -377,9 +380,10 @@ where
     }
 }
 
-impl<'a, A, T: 'a> Iterator for IntoIter<A, T>
+impl<'a, A, T> Iterator for IntoIter<A, T>
 where
     A: Address,
+    T: 'a + Clone + Copy + Default,
 {
     type Item = (A, u32, T);
 
@@ -396,6 +400,7 @@ where
 impl<A, T> IntoIterator for IpLookupTable<A, T>
 where
     A: Address,
+    T: Clone + Copy + Default,
 {
     type Item = (A, u32, T);
     type IntoIter = IntoIter<A, T>;
@@ -411,7 +416,7 @@ where
 /// Iterator over prefixes and associated values. The prefixes are returned in
 /// "tree"-order.
 #[doc(hidden)]
-pub struct Iter<'a, A, T: 'a> {
+pub struct Iter<'a, A, T: 'a + Clone + Copy + Default> {
     inner: tree_bitmap::Iter<'a, T>,
     _addrtype: PhantomData<A>,
 }
@@ -419,7 +424,7 @@ pub struct Iter<'a, A, T: 'a> {
 /// Mutable iterator over prefixes and associated values. The prefixes are
 /// returned in "tree"-order.
 #[doc(hidden)]
-pub struct IterMut<'a, A, T: 'a> {
+pub struct IterMut<'a, A, T: 'a + Clone + Copy + Default> {
     inner: tree_bitmap::IterMut<'a, T>,
     _addrtype: PhantomData<A>,
 }
@@ -427,7 +432,7 @@ pub struct IterMut<'a, A, T: 'a> {
 /// Converts ```IpLookupTable``` into an iterator. The prefixes are returned in
 /// "tree"-order.
 #[doc(hidden)]
-pub struct IntoIter<A, T> {
+pub struct IntoIter<A, T: Clone + Copy + Default> {
     inner: tree_bitmap::IntoIter<T>,
     _addrtype: PhantomData<A>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use treebitmap::IpLookupTable;
+    /// use ip_network_table_deps_treebitmap::IpLookupTable;
     /// use std::net::Ipv6Addr;
     ///
     /// let mut table = IpLookupTable::new();
@@ -106,7 +106,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use treebitmap::IpLookupTable;
+    /// use ip_network_table_deps_treebitmap::IpLookupTable;
     /// use std::net::Ipv6Addr;
     ///
     /// let mut table = IpLookupTable::new();
@@ -132,7 +132,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use treebitmap::IpLookupTable;
+    /// use ip_network_table_deps_treebitmap::IpLookupTable;
     /// use std::net::Ipv6Addr;
     ///
     /// let mut table = IpLookupTable::new();
@@ -154,7 +154,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use treebitmap::IpLookupTable;
+    /// use ip_network_table_deps_treebitmap::IpLookupTable;
     /// use std::net::Ipv6Addr;
     ///
     /// let mut table = IpLookupTable::new();
@@ -180,7 +180,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use treebitmap::IpLookupTable;
+    /// use ip_network_table_deps_treebitmap::IpLookupTable;
     /// use std::net::Ipv6Addr;
     ///
     /// let mut table = IpLookupTable::new();
@@ -212,7 +212,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use treebitmap::IpLookupTable;
+    /// use ip_network_table_deps_treebitmap::IpLookupTable;
     /// use std::net::Ipv6Addr;
     ///
     /// let mut table = IpLookupTable::new();
@@ -244,7 +244,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use treebitmap::IpLookupTable;
+    /// use ip_network_table_deps_treebitmap::IpLookupTable;
     /// use std::net::Ipv6Addr;
     ///
     /// let mut table = IpLookupTable::new();
@@ -282,7 +282,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use treebitmap::IpLookupTable;
+    /// use ip_network_table_deps_treebitmap::IpLookupTable;
     /// use std::net::Ipv6Addr;
     ///
     /// let mut table = IpLookupTable::new();
@@ -308,7 +308,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use treebitmap::IpLookupTable;
+    /// use ip_network_table_deps_treebitmap::IpLookupTable;
     /// use std::net::Ipv6Addr;
     ///
     /// let x: Ipv6Addr = "2001:db8:100::".parse().unwrap();

--- a/src/tree_bitmap/allocator.rs
+++ b/src/tree_bitmap/allocator.rs
@@ -188,7 +188,7 @@ pub fn choose_bucket(len: u32) -> u32 {
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
 #[cfg_attr(feature = "bytecheck", archive_attr(derive(rkyv::CheckBytes)))]
-pub struct Allocator<T: Sized + Clone + Copy + Default> {
+pub struct Allocator<T: Sized> {
     pub(crate) buckets: [BucketVec<T>; 9],
 }
 

--- a/src/tree_bitmap/allocator.rs
+++ b/src/tree_bitmap/allocator.rs
@@ -12,11 +12,16 @@ use std::mem;
 /// A vector that contains `len / spacing` buckets and each bucket contains `spacing` elements.
 /// Buckets are store contiguously in the vector.
 /// So slots are multiples of `spacing`.
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "bytecheck", archive_attr(derive(rkyv::CheckBytes)))]
 pub struct BucketVec<T> {
-    buf: Vec<T>,
+    pub(crate) buf: Vec<T>,
     freelist: Vec<u32>,
     len: u32,
-    spacing: u32,
+    pub(crate) spacing: u32,
 }
 
 impl<T: fmt::Debug> fmt::Debug for BucketVec<T> {
@@ -178,8 +183,13 @@ pub fn choose_bucket(len: u32) -> u32 {
 /// When a bucket becomes full, the contents are moved to a larger bucket. In
 /// this case the allocator will update the caller's pointer.
 #[derive(Debug)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "bytecheck", archive_attr(derive(rkyv::CheckBytes)))]
 pub struct Allocator<T: Sized + Clone + Copy + Default> {
-    buckets: [BucketVec<T>; 9],
+    pub(crate) buckets: [BucketVec<T>; 9],
 }
 
 /// Tracks the size and location of the referenced collection.

--- a/src/tree_bitmap/allocator.rs
+++ b/src/tree_bitmap/allocator.rs
@@ -8,56 +8,12 @@ use alloc::vec::Vec;
 use std::cmp;
 use std::fmt;
 use std::mem;
-use std::ptr;
-use std::slice;
-
-struct RawVec<T> {
-    mem: *mut T,
-    cap: usize,
-}
-
-impl<T> RawVec<T> {
-    pub fn with_capacity(cap: usize) -> RawVec<T> {
-        let mut vec = Vec::<T>::with_capacity(cap);
-        let ptr = vec.as_mut_ptr();
-        mem::forget(vec);
-        RawVec { mem: ptr, cap }
-    }
-
-    pub fn cap(&self) -> usize {
-        self.cap
-    }
-
-    pub fn ptr(&self) -> *mut T {
-        self.mem
-    }
-
-    pub fn reserve(&mut self, used_cap: usize, extra_cap: usize) {
-        let mut vec = unsafe { Vec::<T>::from_raw_parts(self.mem, used_cap, self.cap) };
-        vec.reserve(extra_cap);
-        self.cap = vec.capacity();
-        self.mem = vec.as_mut_ptr();
-        mem::forget(vec);
-    }
-}
-
-impl<T> Drop for RawVec<T> {
-    fn drop(&mut self) {
-        unsafe {
-            Vec::from_raw_parts(self.mem, 0, self.cap);
-        }
-    }
-}
-
-unsafe impl<T> Sync for RawVec<T> where T: Sync {}
-
-unsafe impl<T> Send for RawVec<T> where T: Send {}
 
 /// A vector that contains `len / spacing` buckets and each bucket contains `spacing` elements.
 /// Buckets are store contiguously in the vector.
 /// So slots are multiples of `spacing`.
 pub struct BucketVec<T> {
-    buf: RawVec<T>,
+    buf: Vec<T>,
     freelist: Vec<u32>,
     len: u32,
     spacing: u32,
@@ -69,18 +25,16 @@ impl<T: fmt::Debug> fmt::Debug for BucketVec<T> {
             .field("spacing", &self.spacing)
             .field("freelist", &self.freelist)
             .field("len", &self.len)
-            .field("cap", &self.buf.cap())
-            .field("buf", unsafe {
-                &slice::from_raw_parts(self.buf.ptr(), self.len as usize)
-            })
+            .field("cap", &self.buf.capacity())
+            .field("buf", &&self.buf[..self.len as usize])
             .finish()
     }
 }
 
-impl<T: Sized> BucketVec<T> {
+impl<T: Sized + Clone + Copy + Default> BucketVec<T> {
     pub fn with_capacity(spacing: u32, capacity: usize) -> BucketVec<T> {
         BucketVec {
-            buf: RawVec::with_capacity(capacity),
+            buf: Vec::with_capacity(capacity),
             freelist: Vec::with_capacity(32),
             len: 0,
             spacing,
@@ -97,16 +51,8 @@ impl<T: Sized> BucketVec<T> {
         match self.freelist.pop() {
             Some(n) => n,
             None => {
-                self.buf.reserve(self.len as usize, self.spacing as usize);
-                if cfg!(debug_assertions) {
-                    unsafe {
-                        ptr::write_bytes(
-                            self.buf.ptr().offset(self.len as isize),
-                            0,
-                            self.spacing as usize,
-                        );
-                    }
-                }
+                self.buf
+                    .resize(self.len as usize + self.spacing as usize, T::default());
                 let slot = self.len;
                 self.len += self.spacing;
                 slot
@@ -122,41 +68,29 @@ impl<T: Sized> BucketVec<T> {
     #[inline]
     pub fn get_slot_entry(&self, slot: u32, index: u32) -> &T {
         debug_assert!(slot % self.spacing == 0);
-        let offset = slot + index;
-        unsafe {
-            let src_ptr = self.buf.ptr().offset(offset as isize);
-            &*src_ptr
-        }
+        let offset = (slot + index) as usize;
+        &self.buf[offset]
     }
 
     #[inline]
     pub fn get_slot_entry_mut(&mut self, slot: u32, index: u32) -> &mut T {
         debug_assert!(slot % self.spacing == 0);
-        let offset = slot + index;
-        unsafe {
-            let src_ptr = self.buf.ptr().offset(offset as isize);
-            &mut *src_ptr
-        }
+        let offset = (slot + index) as usize;
+        &mut self.buf[offset]
     }
 
     pub fn set_slot_entry(&mut self, slot: u32, index: u32, value: T) {
         debug_assert!(slot % self.spacing == 0);
         debug_assert!(index < self.spacing);
-        let offset = slot + index;
-        unsafe {
-            let dst_ptr = self.buf.ptr().offset(offset as isize);
-            ptr::write(dst_ptr, value);
-        }
+        let offset = (slot + index) as usize;
+        self.buf[offset] = value;
     }
 
     pub fn replace_slot_entry(&mut self, slot: u32, index: u32, value: T) -> T {
         debug_assert!(slot % self.spacing == 0);
         debug_assert!(index < self.spacing);
-        let offset = slot + index;
-        unsafe {
-            let dst_ptr = self.buf.ptr().offset(offset as isize);
-            ptr::replace(dst_ptr, value)
-        }
+        let offset = (slot + index) as usize;
+        mem::replace(&mut self.buf[offset], value)
     }
 
     /// Insert ```value``` into ```slot``` at ```index```. Values to the right
@@ -164,35 +98,29 @@ impl<T: Sized> BucketVec<T> {
     /// If all values have been set the last value will be lost.
     pub fn insert_slot_entry(&mut self, slot: u32, index: u32, value: T) {
         debug_assert!(slot % self.spacing == 0);
-        let offset = slot + index;
-        unsafe {
-            let dst_ptr = self.buf.ptr().offset(offset as isize);
-            ptr::copy(
-                dst_ptr,
-                dst_ptr.offset(1),
-                (self.spacing - index - 1) as usize,
-            );
-            ptr::write(dst_ptr, value);
-        }
+        let offset = (slot + index) as usize;
+        let end = offset + (self.spacing - index) as usize;
+
+        // Rotate right to make space for the new element
+        self.buf[offset..end].rotate_right(1);
+        self.buf[offset] = value;
     }
 
     pub fn remove_slot_entry(&mut self, slot: u32, index: u32) -> T {
         debug_assert!(slot % self.spacing == 0);
         debug_assert!(index < self.spacing);
-        let offset = slot + index;
-        let ret: T;
-        unsafe {
-            ret = ptr::read(self.buf.ptr().offset(offset as isize));
-            let dst_ptr = self.buf.ptr().offset(offset as isize);
-            ptr::copy(
-                dst_ptr.offset(1),
-                dst_ptr,
-                (self.spacing - index - 1) as usize,
-            );
-            if cfg!(debug_assertions) {
-                ptr::write_bytes(dst_ptr.offset((self.spacing - index - 1) as isize), 0, 1);
-            }
+        let offset = (slot + index) as usize;
+        let end = offset + (self.spacing - index) as usize;
+
+        // Store the value to return
+        let ret = self.buf[offset];
+        // Rotate left to remove the element and shift everything after it
+        self.buf[offset..end].rotate_left(1);
+
+        if cfg!(debug_assertions) {
+            self.buf[end - 1] = T::default();
         }
+
         ret
     }
 
@@ -208,14 +136,15 @@ impl<T: Sized> BucketVec<T> {
         debug_assert!(nitems <= dst.spacing);
 
         let dst_slot = dst.alloc_slot();
+        let src_start = slot as usize;
+        let src_end = src_start + nitems as usize;
+        let dst_start = dst_slot as usize;
+        let dst_end = dst_start + nitems as usize;
 
-        unsafe {
-            let src_ptr = self.buf.ptr().offset(slot as isize);
-            let dst_ptr = dst.buf.ptr().offset(dst_slot as isize);
-            ptr::copy_nonoverlapping(src_ptr, dst_ptr, nitems as usize);
-            if cfg!(debug_assertions) {
-                ptr::write_bytes(src_ptr, 0, nitems as usize);
-            }
+        dst.buf[dst_start..dst_end].copy_from_slice(&self.buf[src_start..src_end]);
+
+        if cfg!(debug_assertions) {
+            self.buf[src_start..src_end].fill(T::default());
         }
 
         self.free_slot(slot);
@@ -224,7 +153,7 @@ impl<T: Sized> BucketVec<T> {
     }
 
     pub fn mem_usage(&self) -> usize {
-        (mem::size_of::<T>() * self.buf.cap()) + (self.freelist.capacity() * mem::size_of::<u32>())
+        (size_of::<T>() * self.buf.capacity()) + (self.freelist.capacity() * size_of::<u32>())
     }
 }
 
@@ -249,7 +178,7 @@ pub fn choose_bucket(len: u32) -> u32 {
 /// When a bucket becomes full, the contents are moved to a larger bucket. In
 /// this case the allocator will update the caller's pointer.
 #[derive(Debug)]
-pub struct Allocator<T: Sized> {
+pub struct Allocator<T: Sized + Clone + Copy + Default> {
     buckets: [BucketVec<T>; 9],
 }
 
@@ -269,7 +198,7 @@ impl AllocatorHandle {
     }
 }
 
-impl<T: Sized> Allocator<T> {
+impl<T: Sized + Clone + Copy + Default> Allocator<T> {
     /// Initialize a new allocator with default capacity.
     #[allow(dead_code)]
     pub fn new() -> Allocator<T> {

--- a/src/tree_bitmap/mod.rs
+++ b/src/tree_bitmap/mod.rs
@@ -22,6 +22,7 @@ use self::node::{MatchResult, Node};
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
 #[cfg_attr(feature = "bytecheck", archive_attr(derive(rkyv::CheckBytes)))]
+#[derive(Debug)]
 pub struct TreeBitmap<T: Sized> {
     trienodes: Allocator<Node>,
     results: Allocator<T>,

--- a/src/tree_bitmap/mod.rs
+++ b/src/tree_bitmap/mod.rs
@@ -22,7 +22,7 @@ use self::node::{MatchResult, Node};
     derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
 )]
 #[cfg_attr(feature = "bytecheck", archive_attr(derive(rkyv::CheckBytes)))]
-pub struct TreeBitmap<T: Sized + Clone + Copy + Default> {
+pub struct TreeBitmap<T: Sized> {
     trienodes: Allocator<Node>,
     results: Allocator<T>,
     len: usize,
@@ -391,13 +391,13 @@ struct PathElem {
     pos: usize,
 }
 
-pub struct Iter<'a, T: 'a + Clone + Copy + Default> {
+pub struct Iter<'a, T: 'a> {
     inner: &'a TreeBitmap<T>,
     path: Vec<PathElem>,
     nibbles: Vec<u8>,
 }
 
-pub struct IterMut<'a, T: 'a + Clone + Copy + Default> {
+pub struct IterMut<'a, T: 'a> {
     inner: &'a mut TreeBitmap<T>,
     path: Vec<PathElem>,
     nibbles: Vec<u8>,
@@ -413,7 +413,7 @@ static PREFIX_OF_BIT: [u8; 32] = [// 0       1       2      3        4       5  
                                   // 24      25      26      27      28      29      30      31
                                   0b1000, 0b1001, 0b1010, 0b1011, 0b1100, 0b1101, 0b1110, 0b1111];
 
-fn next<T: Sized + Clone + Copy + Default>(
+fn next<T: Sized>(
     trie: &TreeBitmap<T>,
     path: &mut Vec<PathElem>,
     nibbles: &mut Vec<u8>,
@@ -488,7 +488,7 @@ impl<'a, T: 'a + Clone + Copy + Default> Iterator for IterMut<'a, T> {
     }
 }
 
-pub struct IntoIter<T: Clone + Copy + Default> {
+pub struct IntoIter<T> {
     inner: TreeBitmap<T>,
     path: Vec<PathElem>,
     nibbles: Vec<u8>,
@@ -526,7 +526,7 @@ impl<T: Clone + Copy + Default> IntoIterator for TreeBitmap<T> {
     }
 }
 
-pub struct MatchesMut<'a, T: 'a + Clone + Copy + Default> {
+pub struct MatchesMut<'a, T: 'a> {
     inner: &'a mut TreeBitmap<T>,
     path: std::vec::IntoIter<(u32, AllocatorHandle, u32)>,
 }
@@ -546,7 +546,7 @@ impl<'a, T: 'a + Clone + Copy + Default> Iterator for MatchesMut<'a, T> {
     }
 }
 
-impl<T: Clone + Copy + Default> TrieAccess for TreeBitmap<T> {
+impl<T> TrieAccess for TreeBitmap<T> {
     fn get_node(&self, hdl: &AllocatorHandle, index: u32) -> Node {
         *self.trienodes.get(&hdl, index)
     }

--- a/src/tree_bitmap/mod.rs
+++ b/src/tree_bitmap/mod.rs
@@ -363,7 +363,7 @@ impl<T: Sized> TreeBitmap<T> {
                         Some((result_hdl, result_index))
                     }
                     _ => None,
-                }
+                };
             }
 
             match cur_node.match_external(bitmap) {
@@ -378,15 +378,13 @@ impl<T: Sized> TreeBitmap<T> {
     }
 
     pub fn exact_match(&self, nibbles: &[u8], masklen: u32) -> Option<&T> {
-        self.exact_match_internal(nibbles, masklen).map(move |(result_hdl, result_index)| {
-            self.results.get(&result_hdl, result_index)
-        })
+        self.exact_match_internal(nibbles, masklen)
+            .map(move |(result_hdl, result_index)| self.results.get(&result_hdl, result_index))
     }
 
     pub fn exact_match_mut(&mut self, nibbles: &[u8], masklen: u32) -> Option<&mut T> {
-        self.exact_match_internal(nibbles, masklen).map(move |(result_hdl, result_index)| {
-            self.results.get_mut(&result_hdl, result_index)
-        })
+        self.exact_match_internal(nibbles, masklen)
+            .map(move |(result_hdl, result_index)| self.results.get_mut(&result_hdl, result_index))
     }
 
     /// Remove prefix. Returns existing value if the prefix previously existed.

--- a/src/tree_bitmap/node.rs
+++ b/src/tree_bitmap/node.rs
@@ -102,9 +102,14 @@ pub fn gen_bitmap(prefix: u8, masklen: u32) -> u32 {
 /// The pointer to the child node is then computed with the ```child_ptr``` base
 /// pointer and the number of bits set left of N.
 #[derive(Clone, Copy, Default)]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(rkyv::Archive, rkyv::Deserialize, rkyv::Serialize)
+)]
+#[cfg_attr(feature = "bytecheck", archive_attr(derive(rkyv::CheckBytes)))]
 pub struct Node {
     /// child/result bitmap
-    bitmap: u32, // first 16 bits: internal, last 16 bits: child bitmap
+    pub(crate) bitmap: u32, // first 16 bits: internal, last 16 bits: child bitmap
     /// child base pointer
     pub child_ptr: u32,
     /// results base pointer

--- a/src/tree_bitmap/node.rs
+++ b/src/tree_bitmap/node.rs
@@ -101,7 +101,7 @@ pub fn gen_bitmap(prefix: u8, masklen: u32) -> u32 {
 /// If bit N is set it means that a child node with segment value N is present.
 /// The pointer to the child node is then computed with the ```child_ptr``` base
 /// pointer and the number of bits set left of N.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct Node {
     /// child/result bitmap
     bitmap: u32, // first 16 bits: internal, last 16 bits: child bitmap

--- a/src/tree_bitmap/rkyv_impl.rs
+++ b/src/tree_bitmap/rkyv_impl.rs
@@ -108,22 +108,26 @@ mod tests {
 
         let ip_2 = Ipv6Addr::new(0x2001, 0xdb8, 0xcafe, 0xf00, 0xf00, 0xf00, 0, 1);
         assert_eq!(table.longest_match(ip_2), Some((less_specific, 32, &123)));
+        rkyv::to_bytes::<_, 1024>(&table).unwrap();
 
-        let rkyv_bytes = rkyv::to_bytes::<_, 1024>(&table).unwrap();
-        let rkyv_table =
-            rkyv::check_archived_root::<IpLookupTable<Ipv6Addr, i32>>(&rkyv_bytes).unwrap();
+        #[cfg(feature = "bytecheck")]
+        {
+            let rkyv_bytes = rkyv::to_bytes::<_, 1024>(&table).unwrap();
+            let rkyv_table =
+                rkyv::check_archived_root::<IpLookupTable<Ipv6Addr, i32>>(&rkyv_bytes).unwrap();
 
-        assert!(!rkyv_table.is_empty());
-        assert_eq!(rkyv_table.len(), 2);
+            assert!(!rkyv_table.is_empty());
+            assert_eq!(rkyv_table.len(), 2);
 
-        assert_eq!(rkyv_table.exact_match(ip_1, 48), Some(&321));
-        assert_eq!(
-            rkyv_table.longest_match(ip_1),
-            Some((more_specific, 48, &321))
-        );
-        assert_eq!(
-            rkyv_table.longest_match(ip_2),
-            Some((less_specific, 32, &123))
-        );
+            assert_eq!(rkyv_table.exact_match(ip_1, 48), Some(&321));
+            assert_eq!(
+                rkyv_table.longest_match(ip_1),
+                Some((more_specific, 48, &321))
+            );
+            assert_eq!(
+                rkyv_table.longest_match(ip_2),
+                Some((less_specific, 32, &123))
+            );
+        }
     }
 }

--- a/src/tree_bitmap/rkyv_impl.rs
+++ b/src/tree_bitmap/rkyv_impl.rs
@@ -1,0 +1,129 @@
+use address::Address;
+use rkyv::{Archive, Archived};
+use tree_bitmap::node::ArchivedNode;
+use tree_bitmap::{
+    allocator::{choose_bucket, AllocatorHandle, ArchivedAllocator, ArchivedBucketVec},
+    node::Node,
+    ArchivedTreeBitmap, TrieAccess,
+};
+use ArchivedIpLookupTable;
+
+impl<A: Address, T: Archive + Clone + Copy + Default> ArchivedIpLookupTable<A, T> {
+    /// Return number of items inside table.
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    /// Return `true` if no item is inside table.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Longest match lookup of `ip`
+    pub fn longest_match(&self, ip: A) -> Option<(A, u32, &Archived<T>)> {
+        match self.inner.longest_match(&ip.nibbles().as_ref()) {
+            Some((bits_matched, value)) => Some((ip.mask(bits_matched), bits_matched, value)),
+            None => None,
+        }
+    }
+
+    /// Perform exact match lookup of `ip` and `masklen` and return the value.
+    pub fn exact_match(&self, ip: A, masklen: u32) -> Option<&Archived<T>> {
+        self.inner.exact_match(&ip.nibbles().as_ref(), masklen)
+    }
+}
+
+impl<T: Archive + Clone + Copy + Default> ArchivedTreeBitmap<T> {
+    /// Return number of items inside table.
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    /// Longest match lookup of `nibbles`. Returns bits matched as u32, and reference to T.
+    pub fn longest_match(&self, nibbles: &[u8]) -> Option<(u32, &Archived<T>)> {
+        match self.longest_match_internal(&nibbles) {
+            Some((result_hdl, result_index, bits_matched)) => {
+                Some((bits_matched, self.results.get(&result_hdl, result_index)))
+            }
+            None => None,
+        }
+    }
+
+    /// Perform exact match lookup of `nibbles` and `masklen` and return the value.
+    pub fn exact_match(&self, nibbles: &[u8], masklen: u32) -> Option<&Archived<T>> {
+        self.exact_match_internal(nibbles, masklen)
+            .map(|(result_hdl, result_index)| self.results.get(&result_hdl, result_index))
+    }
+}
+
+impl<T: Archive + Clone + Copy + Default> TrieAccess for ArchivedTreeBitmap<T> {
+    fn get_node(&self, hdl: &AllocatorHandle, index: u32) -> Node {
+        Node::from(self.trienodes.get(&hdl, index))
+    }
+}
+
+impl<T: Archive + Clone + Copy + Default> ArchivedAllocator<T> {
+    #[inline]
+    pub fn get(&self, hdl: &AllocatorHandle, index: u32) -> &Archived<T> {
+        let bucket_index = choose_bucket(hdl.len) as usize;
+        self.buckets[bucket_index].get_slot_entry(hdl.offset, index)
+    }
+}
+
+impl<T: Archive + Clone + Copy + Default> ArchivedBucketVec<T> {
+    #[inline]
+    pub fn get_slot_entry(&self, slot: u32, index: u32) -> &Archived<T> {
+        debug_assert!(slot % self.spacing == 0);
+        let offset = (slot + index) as usize;
+        &self.buf[offset]
+    }
+}
+
+impl From<&ArchivedNode> for Node {
+    fn from(v: &ArchivedNode) -> Self {
+        Node {
+            bitmap: v.bitmap,
+            child_ptr: v.child_ptr,
+            result_ptr: v.result_ptr,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv6Addr;
+    use IpLookupTable;
+
+    #[test]
+    fn test_rkyv() {
+        let mut table = IpLookupTable::new();
+        let less_specific = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0);
+        let more_specific = Ipv6Addr::new(0x2001, 0xdb8, 0xdead, 0, 0, 0, 0, 0);
+        table.insert(less_specific, 32, 123);
+        table.insert(more_specific, 48, 321);
+
+        let ip_1 = Ipv6Addr::new(0x2001, 0xdb8, 0xdead, 0xbeef, 0xcafe, 0xbabe, 0, 1);
+        assert_eq!(table.longest_match(ip_1), Some((more_specific, 48, &321)));
+        assert_eq!(table.exact_match(ip_1, 48), Some(&321));
+
+        let ip_2 = Ipv6Addr::new(0x2001, 0xdb8, 0xcafe, 0xf00, 0xf00, 0xf00, 0, 1);
+        assert_eq!(table.longest_match(ip_2), Some((less_specific, 32, &123)));
+
+        let rkyv_bytes = rkyv::to_bytes::<_, 1024>(&table).unwrap();
+        let rkyv_table =
+            rkyv::check_archived_root::<IpLookupTable<Ipv6Addr, i32>>(&rkyv_bytes).unwrap();
+
+        assert!(!rkyv_table.is_empty());
+        assert_eq!(rkyv_table.len(), 2);
+
+        assert_eq!(rkyv_table.exact_match(ip_1, 48), Some(&321));
+        assert_eq!(
+            rkyv_table.longest_match(ip_1),
+            Some((more_specific, 48, &321))
+        );
+        assert_eq!(
+            rkyv_table.longest_match(ip_2),
+            Some((less_specific, 32, &123))
+        );
+    }
+}

--- a/tests/rand_test.rs
+++ b/tests/rand_test.rs
@@ -1,12 +1,11 @@
-extern crate rand;
 extern crate ip_network_table_deps_treebitmap;
+extern crate rand;
 
-use std::mem;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use self::rand::{thread_rng, Rng};
 use ip_network_table_deps_treebitmap::address::Address;
 use ip_network_table_deps_treebitmap::IpLookupTable;
-use self::rand::{thread_rng, Rng};
-
+use std::mem;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 const NUMBER_OF_ITERS: usize = 10; // number of times to run each test
 const NUMBER_OF_PEERS: usize = 64; // number of distinct values
@@ -127,7 +126,7 @@ impl<T, A: Address> SlowRouter<T, A> {
 }
 
 #[test]
-#[cfg(not(miri))]  // miri is too slow
+#[cfg(not(miri))] // miri is too slow
 fn ipv6_random_test() {
     for _ in 0..NUMBER_OF_ITERS {
         let mut tbl = IpLookupTable::new();

--- a/tests/rand_test.rs
+++ b/tests/rand_test.rs
@@ -1,13 +1,12 @@
 extern crate rand;
-extern crate treebitmap;
+extern crate ip_network_table_deps_treebitmap;
 
 use std::mem;
 use std::net::{Ipv4Addr, Ipv6Addr};
-
+use ip_network_table_deps_treebitmap::address::Address;
+use ip_network_table_deps_treebitmap::IpLookupTable;
 use self::rand::{thread_rng, Rng};
 
-use treebitmap::address::Address;
-use treebitmap::*;
 
 const NUMBER_OF_ITERS: usize = 10; // number of times to run each test
 const NUMBER_OF_PEERS: usize = 64; // number of distinct values

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,13 +4,13 @@
 // This file may not be copied, modified, or distributed except according to those terms.
 //
 
-extern crate treebitmap;
+extern crate ip_network_table_deps_treebitmap;
 
 mod rand_test;
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
-use treebitmap::*;
+use ip_network_table_deps_treebitmap::IpLookupTable;
 
 #[test]
 #[should_panic]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -8,9 +8,9 @@ extern crate ip_network_table_deps_treebitmap;
 
 mod rand_test;
 
+use ip_network_table_deps_treebitmap::IpLookupTable;
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
-use ip_network_table_deps_treebitmap::IpLookupTable;
 
 #[test]
 #[should_panic]


### PR DESCRIPTION
[rkyv](http://github.com/rkyv/rkyv) (archive) is a zero-copy deserialization framework for Rust.

This will enable use of `IpLookupTable` data structure in zero-copy fashion, e.g. using memory-mapped file with [mmap-sync](https://github.com/cloudflare/mmap-sync) crate.